### PR TITLE
feat: remove imps from the nether

### DIFF
--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -23,6 +23,15 @@
         "mob": "vampirism:hunter",
         "mincount": 20,
         "result": "deny"
+      },  
+      {
+        "mob": "mythsandlegends:imp",
+        "when": "onjoin",
+        "result": "deny"
+      },  
+      {
+        "mob": "mythsandlegends:imp_clone",
+        "when": "onjoin",
+        "result": "deny"
       }
-
 ]


### PR DESCRIPTION
So... I don't like the imps.  They seem overpowered, especially for early game, so I wanted to propose that they get removed.

This is written to also account for any exist imp clones that could exist in your world.  I did opt for `"when": "onjoin"` since my initial test without didn't seem to make a difference.