### PR TITLE
Changed Energy Acceptor quest to be a checkmark

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -90,8 +90,7 @@
 			shape: "diamond"
 			tasks: [{
 				id: "5B4DDF66C36AF356"
-				item: { count: 1, id: "ae2:energy_acceptor" }
-				type: "item"
+				type: "checkmark"
 			}]
 			x: 3.0d
 			y: -0.5d


### PR DESCRIPTION
Changed the Energy Acceptor quest in the Applied Energistics  2 chapter to be a checkmark. The original quest required an Energy Acceptor which has been removed from the pack. 