### PR TITLE
Updated quests to remove Mob Grinding Utils rewards

### DIFF
--- a/config/ftbquests/quests/chapters/forbidden__arcanus.snbt
+++ b/config/ftbquests/quests/chapters/forbidden__arcanus.snbt
@@ -474,7 +474,7 @@
 				id: "6D21710E315BC55A"
 				item: {
 					components: {
-						"ftbquests:missing_item": "mob_grinding_utils:spikes"
+						"ftbquests:missing_item": "evilcraft:spiked_plate"
 					}
 					count: 1
 					id: "ftbquests:missing_item"

--- a/config/ftbquests/quests/chapters/mahou_tsukai.snbt
+++ b/config/ftbquests/quests/chapters/mahou_tsukai.snbt
@@ -863,7 +863,7 @@
 				id: "6B765B1257BF468B"
 				item: {
 					components: {
-						"ftbquests:missing_item": "mob_grinding_utils:delightful_dirt"
+						"ftbquests:missing_item": "minecraft:spawner"
 					}
 					count: 1
 					id: "ftbquests:missing_item"


### PR DESCRIPTION
Updated two quests to remove the reward for Mob Grinding Utils items. 