### PR TITLE
feat: allow darkstone to be used with quarry bees

### DIFF
--- a/kubejs/server_scripts/forbiddenarcanus/tags.js
+++ b/kubejs/server_scripts/forbiddenarcanus/tags.js
@@ -1,0 +1,16 @@
+/*
+*    This File has been authored by AllTheMods Staff, or a Community contributor for use in `All the Magic: Arcana` by ATMTeam.
+*    As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+*/
+ServerEvents.tags(`item`, ATM => {
+  ATM.add('productivebees:flowers/quarry', ['forbidden_arcanus:darkstone'])
+})
+
+ServerEvents.tags(`block`, ATM => {
+  ATM.add('productivebees:flowers/quarry', ['forbidden_arcanus:darkstone'])
+})
+
+/*
+*    This File has been authored by AllTheMods Staff, or a Community contributor for use in `All the Magic: Arcana` by ATMTeam.
+*    As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+*/


### PR DESCRIPTION
I like bees... and I don't want to manually mine darkstone, so I wanted to allow quarry bees to work with darkstone.

I did test this locally and my quarry bees are quite happy with mining darkstone now!